### PR TITLE
Fix sidecar graceful termination

### DIFF
--- a/charts/blockchain-etl-streaming/templates/deployment.yaml
+++ b/charts/blockchain-etl-streaming/templates/deployment.yaml
@@ -149,13 +149,9 @@ spec:
           image: "{{ .Values.upload.image.repository }}:{{ .Values.upload.image.tag }}"
           imagePullPolicy: {{ .Values.upload.image.pullPolicy }}
           command:
-            - watch
-            - "-n"
-            - "60"
-            - gsutil
-            - cp
-            - {{ .Values.lsb_path }}/{{ .Values.lsb_file }}
-            - {{ .Values.config.GCS_PREFIX }}/{{ .Values.lsb_file }}
+            - sh
+            - -c
+            - "apk add --no-cache tini && exec tini watch -n 60 gsutil cp {{ .Values.lsb_path }}/{{ .Values.lsb_file }} {{ .Values.config.GCS_PREFIX }}/{{ .Values.lsb_file }}"
           volumeMounts:
             - name: google-cloud-key
               mountPath: /var/secrets/google

--- a/charts/blockchain-etl-streaming/templates/deployment.yaml
+++ b/charts/blockchain-etl-streaming/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         rootEntitiType: {{ .Values.config.ROOT_ENTITY_TYPE }}
         {{- end }}
     spec:
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: google-cloud-key
           secret:

--- a/example_values/ethereum/values.yaml
+++ b/example_values/ethereum/values.yaml
@@ -6,3 +6,4 @@ config:
   PROVIDER_URI: https://mainnet.infura.io
   ENTITY_TYPES: block,transaction,log,token_transfer
   LAG_BLOCKS: 18
+  CHAIN: null


### PR DESCRIPTION
SSIA. It works as expected in my tests with increased `terminationGracePeriodSeconds`.
Download inside container runtime is a bad practice, but I don't expect this container to fail in restart loop.