### PR TITLE
Fix exit code

### DIFF
--- a/charts/blockchain-etl-streaming/Chart.yaml
+++ b/charts/blockchain-etl-streaming/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.5"
 description: A Helm chart to deploy multiple blockchain ETL streaming apps
 name: blockchain-etl-streaming
-version: 0.1.12
+version: 0.1.13

--- a/charts/blockchain-etl-streaming/templates/deployment.yaml
+++ b/charts/blockchain-etl-streaming/templates/deployment.yaml
@@ -140,7 +140,7 @@ spec:
           command:
             - sh
             - -c
-            - "apk add --no-cache tini && exec tini watch -n 60 gsutil cp {{ .Values.lsb_path }}/{{ .Values.lsb_file }} {{ .Values.config.GCS_PREFIX }}/{{ .Values.lsb_file }}"
+            - "apk add --no-cache tini && exec tini -e 143 watch -n 60 gsutil cp {{ .Values.lsb_path }}/{{ .Values.lsb_file }} {{ .Values.config.GCS_PREFIX }}/{{ .Values.lsb_file }}"
           volumeMounts:
             - name: google-cloud-key
               mountPath: /var/secrets/google

--- a/charts/blockchain-etl-streaming/templates/deployment.yaml
+++ b/charts/blockchain-etl-streaming/templates/deployment.yaml
@@ -169,7 +169,7 @@ spec:
                   - "while [ -f {{ .Values.lsb_path }}/{{ .Values.pid_file }} ]; do sleep 1; done;
                 gsutil cp {{ .Values.lsb_path }}/{{ .Values.lsb_file }} ${GCS_PREFIX}/{{ .Values.lsb_file }}"
           resources:
-            {{- toYaml .Values.init.resources | nindent 12 }}
+            {{- toYaml .Values.upload.resources | nindent 12 }}
         {{- if .Values.cloudSqlProxy.enabled }}
         - name: cloudsql-proxy
           image: "{{ .Values.cloudSqlProxy.image.repository }}:{{ .Values.cloudSqlProxy.image.tag }}"


### PR DESCRIPTION
We  mask `watch` exit code from `upload-last-synced-block-file` container as `success` via `tini` arg just to tell container platform about clean shutdown.
Fixes #9